### PR TITLE
Support language tags with more than one hyphen

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ export const virtualModuleId = 'virtual:i18next-loader'
 export const resolvedVirtualModuleId = '\0' + virtualModuleId
 
 export function jsNormalizedLang(lang: string) {
-  return lang.replace(/-/, '_')
+  return lang.replace(/-/g, '_')
 }
 
 export function enumerateLangs(dir: string) {


### PR DESCRIPTION
Language tags are composed of one or more subtags (reference: https://en.wikipedia.org/wiki/IETF_language_tag) and are not limited to two subtags with one hyphen. Fixed the "jsNormalizedLang" utility function to support more than one hyphen (for example, "zh-Hant-HK").

Before this fix, such language tags would cause invalid code to be generated, such as:
`export const zh_Hant-HK = {"translation":{"layouts":{"header":{"title":"Example Title"}}}`