### PR TITLE
Add actions triggers for external PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, edited, reopened, review_requested]
+    types: [opened, reopened, review_requested]
     branches: [main]
 
 jobs:
@@ -15,14 +15,14 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Prepare repository
         run: git fetch --unshallow --tags
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
 
       # allow the lock file to change (updating our own workspace versions in monorepo)
@@ -31,7 +31,7 @@ jobs:
       - run: yarn test
 
       # commit back the lock file change if it works
-      - uses: stefanzweifel/git-auto-commit-action@v4
+      - uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Apply yarn.lock changes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,10 +2,16 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches: [main, next]
   pull_request:
-    types: [opened, reopened, review_requested]
-    branches: [main]
+    types: [opened, synchronize, reopened]
+
+# on:
+#   push:
+#     branches: [main]
+#   pull_request:
+#     types: [opened, edited, reopened, review_requested]
+#     branches: [main]
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-# on:
-#   push:
-#     branches: [main]
-#   pull_request:
-#     types: [opened, edited, reopened, review_requested]
-#     branches: [main]
-
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, edited, reopened, review_requested]
+    branches: [main]
 
 jobs:
   release:
@@ -17,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           cache: 'yarn'
 
       # allow the lock file to change (updating our own workspace versions in monorepo)


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.5--canary.15.7849254042.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install vite-plugin-i18next-loader@2.0.5--canary.15.7849254042.0
  # or 
  yarn add vite-plugin-i18next-loader@2.0.5--canary.15.7849254042.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
