### PR TITLE
Nodenext compatibility, better HMR 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ This vite-plugin i18next loader generates the `resources` structure necessary fo
 
 ## Features
 
-- [x] glob based file filtering
-- [x] one to many overrides supporting reuse cases (white labeling)
-- [x] yaml and json support
-- [x] hot module reloading (Basic with full reload works, HMR may be improved with vite 3.2 api - see #5)
-- [ ] chunking/tree shaking may already be possible, see #4 - needs more trial/discussion.
+- [x] Glob based file filtering
+- [x] One to many overrides supporting reuse cases (white labeling)
+- [x] Yaml and Json support
+- [x] HMR hot module reloading
+- [ ] Better chunking/tree shaking may already be possible, see https://github.com/alienfast/vite-plugin-i18next-loader/issues/4 - needs more trial/discussion.
 
 Given a locales directory, by default, the loader will find and parse any `json|yaml|yml` file and attribute the
 contents to the containing lang folder e.g. `en`. There is no need to add lang such as `en` or `de` inside your

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -5,9 +5,9 @@ import * as path from 'node:path'
 
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import factory from '../index'
-import { resolvedVirtualModuleId } from '../utils'
-import { esm, ThisScope } from './util'
+import factory from '../index.js'
+import { resolvedVirtualModuleId } from '../utils.js'
+import { esm, ThisScope } from './util.js'
 
 describe('basic', () => {
   for (const type of ['yaml', 'json']) {

--- a/src/__tests__/namespaceResolverBasename.test.ts
+++ b/src/__tests__/namespaceResolverBasename.test.ts
@@ -7,9 +7,9 @@ import * as path from 'node:path'
 
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import factory from '..'
-import { resolvedVirtualModuleId } from '../utils'
-import { esm, ThisScope } from './util'
+import factory from '../index.js'
+import { resolvedVirtualModuleId } from '../utils.js'
+import { esm, ThisScope } from './util.js'
 
 describe('namespaceResolverBasename', () => {
   for (const type of ['yaml', 'json']) {

--- a/src/__tests__/namespaceResolverRelativePath.test.ts
+++ b/src/__tests__/namespaceResolverRelativePath.test.ts
@@ -6,9 +6,9 @@ import * as path from 'node:path'
 
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import factory from '..'
-import { resolvedVirtualModuleId } from '../utils'
-import { esm, ThisScope } from './util'
+import factory from '../index.js'
+import { resolvedVirtualModuleId } from '../utils.js'
+import { esm, ThisScope } from './util.js'
 
 describe('namespaceResolverRelativePath', () => {
   for (const type of ['yaml', 'json']) {

--- a/src/__tests__/pathOverride.test.ts
+++ b/src/__tests__/pathOverride.test.ts
@@ -6,9 +6,9 @@ import * as path from 'node:path'
 
 import { beforeEach, describe, expect, it } from 'vitest'
 
-import factory from '..'
-import { resolvedVirtualModuleId } from '../utils'
-import { esm, ThisScope } from './util'
+import factory from '../index.js'
+import { resolvedVirtualModuleId } from '../utils.js'
+import { esm, ThisScope } from './util.js'
 
 describe('pathOverride', () => {
   for (const type of ['yaml', 'json']) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
   "include": ["src", "typings/**/*"],
   "exclude": ["node_modules", "dist"],
   "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "nodenext",
     "outDir": "dist",
     "rootDir": "src"
   }


### PR DESCRIPTION
Closes #5

I do not believe moving to `nodenext` is a breaking change in any way, so I've only bumped the minor.