### PR TITLE
fix: handle empty YAML locale files gracefully

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,7 @@ const factory = (options: Options) => {
             timestamp: true,
           })
 
-          const content = loadAndParse(langFile)
+          const content = loadAndParse(langFile) ?? {}
 
           if (options.namespaceResolution) {
             let namespaceFilepath: string = langFile


### PR DESCRIPTION
## Problem

When a locale file is empty, `js-yaml`'s `load()` returns `null` instead of an object. This `null` value is then passed directly to either `setProperty` (when `namespaceResolution` is enabled) or used as `resBundle[lang]` (when it isn't). In both cases, a subsequent `merge()` call can silently discard previously loaded content for that locale — i.e. if a locale directory contains both a populated file and an empty file with the same namespace, the empty file's `null` result can overwrite the populated one.

## Fix

Add a `?? {}` fallback after `loadAndParse()` so that empty files are treated as empty objects, leaving all other locale content unaffected.

```diff
- const content = loadAndParse(langFile)
+ const content = loadAndParse(langFile) ?? {}
```