### PR TITLE
fix: respect absolute paths in handleHotUpdate

### DIFF
--- a/src/__tests__/handleHotUpdate.test.ts
+++ b/src/__tests__/handleHotUpdate.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+import * as path from 'node:path'
+
+import { describe, expect, it, vi } from 'vitest'
+
+import factory from '../index.js'
+import { resolvedVirtualModuleId } from '../utils.js'
+
+// eslint-disable-next-line unicorn/prefer-module
+const absoluteLocalesDir = path.join(__dirname, './data/basic-app-yaml/locales')
+
+function makeMockServer() {
+  const fakeModule = { id: resolvedVirtualModuleId }
+  return {
+    moduleGraph: {
+      getModuleById: vi.fn().mockReturnValue(fakeModule),
+    },
+    reloadModule: vi.fn().mockResolvedValue(undefined),
+  }
+}
+
+describe('handleHotUpdate', () => {
+  it.concurrent(
+    'reloads the virtual module when a locale file is edited and paths are absolute',
+    async () => {
+      const plugin = factory({ paths: [absoluteLocalesDir] }) as any
+      const server = makeMockServer()
+      const changedFile = path.join(absoluteLocalesDir, 'en/main.yaml')
+
+      await plugin.handleHotUpdate({ file: changedFile, server })
+
+      expect(server.reloadModule).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it.concurrent(
+    'reloads the virtual module when a locale file is edited and paths are relative to cwd',
+    async () => {
+      const relativeFromCwd = path.relative(process.cwd(), absoluteLocalesDir)
+      const plugin = factory({ paths: [relativeFromCwd] }) as any
+      const server = makeMockServer()
+      const changedFile = path.join(absoluteLocalesDir, 'en/main.yaml')
+
+      await plugin.handleHotUpdate({ file: changedFile, server })
+
+      expect(server.reloadModule).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it.concurrent(
+    'ignores files outside the configured paths',
+    async () => {
+      const plugin = factory({ paths: [absoluteLocalesDir] }) as any
+      const server = makeMockServer()
+      const changedFile = '/tmp/some/other/locale.yaml'
+
+      await plugin.handleHotUpdate({ file: changedFile, server })
+
+      expect(server.reloadModule).not.toHaveBeenCalled()
+    },
+  )
+
+  it.concurrent(
+    'ignores files whose extension is not json/yml/yaml',
+    async () => {
+      const plugin = factory({ paths: [absoluteLocalesDir] }) as any
+      const server = makeMockServer()
+      const changedFile = path.join(absoluteLocalesDir, 'en/main.txt')
+
+      await plugin.handleHotUpdate({ file: changedFile, server })
+
+      expect(server.reloadModule).not.toHaveBeenCalled()
+    },
+  )
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -195,7 +195,9 @@ ${bundle}
     async handleHotUpdate({ file, server }) {
       const isLocaleFile =
         file.match(/\.(json|yml|yaml)$/) &&
-        options.paths.some((p) => file.startsWith(path.join(process.cwd(), p)))
+        options.paths.some((p) =>
+          file.startsWith(path.isAbsolute(p) ? p : path.join(process.cwd(), p)),
+        )
       if (isLocaleFile) {
         log.info(`Changed locale file: ${file}`, {
           timestamp: true,


### PR DESCRIPTION
## Problem

`handleHotUpdate` never reloads the virtual module when `paths` contains an absolute path.

The current check is:

```ts
options.paths.some((p) => file.startsWith(path.join(process.cwd(), p)))
```

`path.join` (unlike `path.resolve`) does **not** strip an absolute prefix from its later arguments — it just concatenates with a separator:

```js
path.join('/cwd', '/Users/me/project/locales')
// → '/cwd/Users/me/project/locales'   ← nonsense
```

So when a consumer passes an absolute path (very common — e.g. `path.resolve(__dirname, '../resources')` in a monorepo where cwd ≠ the project root), the join produces a path no real file starts with, the predicate is always `false`, and HMR for locale files silently does nothing.

This is independent of any Vite version — `handleHotUpdate({ file })` has been absolute since Vite 3.

## Fix

Only join with `process.cwd()` when the configured path is relative; pass absolute paths through as-is.

```ts
options.paths.some((p) =>
  file.startsWith(path.isAbsolute(p) ? p : path.join(process.cwd(), p)),
)
```

## Tests

Adds `src/__tests__/handleHotUpdate.test.ts` covering:

- absolute `paths` → reloadModule is called (regression test for this bug)
- relative `paths` (relative to cwd) → reloadModule is called
- file outside configured paths → reloadModule is NOT called
- file with non-locale extension → reloadModule is NOT called

All 18 tests pass.

## How to reproduce the original bug

In any project where the plugin is configured with an absolute path:

```ts
i18nextLoader({
  paths: [path.resolve(__dirname, 'locales')],
})
```

Edit any locale YAML/JSON and observe that the virtual module is never reloaded; you have to restart Vite to see changes.