### PR TITLE
Token-free CI: public-npm deps, OIDC, built-in GITHUB_TOKEN, pnpm 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,9 +28,9 @@ permissions:
   id-token: write
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-  NPM_TOKEN: ${{ secrets.NPM_TOKEN  }}
-  PROTECTED_BRANCH_REVIEWER_TOKEN: ${{ secrets.GH_TOKEN }}
+  # built-in token: auto creates GitHub releases/labels with it (no PAT to rotate).
+  # npm publish authenticates via OIDC trusted publishing; deps install from public npm.
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # PR: ${{ steps.PR.outputs.number }}
 
 jobs:

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-# provide this for the github actions
-@alienfast:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}

--- a/package.json
+++ b/package.json
@@ -26,17 +26,17 @@
   },
   "description": "Vite plugin loader for client embedded i18next locales composited from one to many json or yaml files.",
   "devDependencies": {
-    "@alienfast/biome-config": "^1.0.5",
+    "@alienfast/biome-config": "^1.0.6",
     "@alienfast/tsconfig": "^1.0.8",
     "@auto-it/all-contributors": "^11.3.6",
     "@auto-it/first-time-contributor": "^11.3.6",
     "@auto-it/released": "^11.3.6",
-    "@biomejs/biome": "^2.4.9",
+    "@biomejs/biome": "^2.4.16",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.9.1",
     "auto": "^11.3.6",
     "execa": "^9.6.1",
-    "i18next": "^26.3.1",
+    "i18next": "26.3.0",
     "npm-run-all": "^4.1.5",
     "rimraf": "^6.1.3",
     "tsdown": "^0.22.1",
@@ -73,15 +73,9 @@
     }
   ],
   "name": "vite-plugin-i18next-loader",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.5.1",
   "peerDependencies": {
     "vite": ">=3.1.6"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@biomejs/biome",
-      "esbuild"
-    ]
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
         version: 8.0.0
     devDependencies:
       '@alienfast/biome-config':
-        specifier: ^1.0.5
-        version: 1.0.5(@biomejs/biome@2.4.16)
+        specifier: ^1.0.6
+        version: 1.0.6(@biomejs/biome@2.4.16)
       '@alienfast/tsconfig':
         specifier: ^1.0.8
         version: 1.0.8
@@ -43,7 +43,7 @@ importers:
         specifier: ^11.3.6
         version: 11.3.6(@types/node@25.9.1)(typescript@6.0.3)
       '@biomejs/biome':
-        specifier: ^2.4.9
+        specifier: ^2.4.16
         version: 2.4.16
       '@types/js-yaml':
         specifier: ^4.0.9
@@ -58,8 +58,8 @@ importers:
         specifier: ^9.6.1
         version: 9.6.1
       i18next:
-        specifier: ^26.3.1
-        version: 26.3.1(typescript@6.0.3)
+        specifier: 26.3.0
+        version: 26.3.0(typescript@6.0.3)
       npm-run-all:
         specifier: ^4.1.5
         version: 4.1.5
@@ -84,14 +84,14 @@ importers:
 
 packages:
 
-  '@alienfast/biome-config@1.0.5':
-    resolution: {integrity: sha512-rPsfTBCUG84B3R1Krsdf+GgMUJWf6krAxlPM5UpRLqluz2TlO4YMW+yOQJZiCxep+YtYb9P/RY3JYcfC2y6EfA==, tarball: https://npm.pkg.github.com/download/@alienfast/biome-config/1.0.5/fc7d96179814131a6d43ec4b41f0fc27d06f4f80}
+  '@alienfast/biome-config@1.0.6':
+    resolution: {integrity: sha512-46Pipbk7GuOd9YtioqVFVAE1yOzcfMgMcI2SirELrEEO63tO/Yg27HLMZmXp8J1nrVvr1kYhrqgIgKg7Drc3Dw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@biomejs/biome': '*'
 
   '@alienfast/tsconfig@1.0.8':
-    resolution: {integrity: sha512-Rp59QQaaCE+ApAR/oLckAV6QRj1SOzLy6jLCEd+Yf9nsDalPNx5xj8IL4zacpAXL40Mvz4aAS7C9bKIhorlWpA==, tarball: https://npm.pkg.github.com/download/@alienfast/tsconfig/1.0.8/3b02848d8027e8f1389ebe6bbd00750238d2bbb7}
+    resolution: {integrity: sha512-Rp59QQaaCE+ApAR/oLckAV6QRj1SOzLy6jLCEd+Yf9nsDalPNx5xj8IL4zacpAXL40Mvz4aAS7C9bKIhorlWpA==}
     engines: {node: '>=16'}
 
   '@auto-it/all-contributors@11.3.6':
@@ -1312,8 +1312,8 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
-  i18next@26.3.1:
-    resolution: {integrity: sha512-txQqd5EULsqEh9OJqRH15aCaOuy/nLJyhw5EHCSKLKJE1aBbb3Zve2+uQIxgWhPm1QqUQoWyQBm2kfmmIrzkcQ==}
+  i18next@26.3.0:
+    resolution: {integrity: sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==}
     peerDependencies:
       typescript: ^5 || ^6
     peerDependenciesMeta:
@@ -2643,7 +2643,7 @@ packages:
 
 snapshots:
 
-  '@alienfast/biome-config@1.0.5(@biomejs/biome@2.4.16)':
+  '@alienfast/biome-config@1.0.6(@biomejs/biome@2.4.16)':
     dependencies:
       '@biomejs/biome': 2.4.16
 
@@ -4013,7 +4013,7 @@ snapshots:
 
   human-signals@8.0.1: {}
 
-  i18next@26.3.1(typescript@6.0.3):
+  i18next@26.3.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,3 +3,7 @@
 allowBuilds:
   '@biomejs/biome': true
   esbuild: true
+# pnpm 11 enforces a default minimumReleaseAge (won't install <24h-old packages).
+# Trust our own org so freshly-published @alienfast releases don't block CI.
+minimumReleaseAgeExclude:
+  - '@alienfast/*'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# pnpm 11 reads settings here, not from the package.json "pnpm" field.
+# https://pnpm.io/settings
+allowBuilds:
+  '@biomejs/biome': true
+  esbuild: true


### PR DESCRIPTION
## Summary

Completes the move to a **fully token-free release pipeline** and bumps to **pnpm 11**. Follows up on #34 (which fixed npm publishing via OIDC) by removing the last long-lived token — the `GH_TOKEN` PAT auto used for GitHub releases, which was the cause of the `v4.0.0` release 404.

## Why

The `v4.0.0` release published to npm (OIDC ✓) but failed to create the GitHub Release: auto's Releases API call used `GH_TOKEN` (a fine-grained PAT that could read packages but lacked Contents: write), returning 404. Rather than rotate another PAT, this removes the PAT entirely.

## Changes

### Token-free releases
- **Drop GitHub Packages routing** — remove `.npmrc`. `@alienfast/biome-config` and `@alienfast/tsconfig` are now consumed from **public npm**, so dependency installs need no token at all. (Requires biome-config ≥ 1.0.5 on public npm, now published as 1.0.6.)
- **auto uses the built-in `GITHUB_TOKEN`** for GitHub releases/labels (it already has `contents`/`issues`/`pull-requests: write` from the workflow `permissions` block). Removed the `GH_TOKEN` PAT, `PROTECTED_BRANCH_REVIEWER_TOKEN`, and the now-unused `NPM_TOKEN` envs from [build.yml](.github/workflows/build.yml).
- npm publish stays on **OIDC trusted publishing** (from #34) — no `NPM_TOKEN`.

Net: no long-lived secrets in the release path — installs use public npm, GitHub releases use the per-run built-in token, npm publish uses OIDC.

### pnpm 10 → 11
- `packageManager: pnpm@11.5.1`.
- pnpm 11 no longer reads the `package.json` `pnpm` field, so build-script approval moves to [pnpm-workspace.yaml](pnpm-workspace.yaml) as `allowBuilds` (the pnpm 11 mechanism; `onlyBuiltDependencies` alone is no longer honored).
- **`minimumReleaseAge` is a pnpm 11 default** (won't install <24h-old packages — a supply-chain delay enforced on every `pnpm install`, including CI). Freshly-published `@alienfast/*` releases (our own org) would block CI, so [pnpm-workspace.yaml](pnpm-workspace.yaml) allowlists the scope via `minimumReleaseAgeExclude: ['@alienfast/*']`. Third-party deps keep the age protection.
- Regenerated `pnpm-lock.yaml` (pnpm 11 format; `@alienfast/*` resolve from public npm).

### Dependency bumps
- `@alienfast/biome-config` `^1.0.6`, `@biomejs/biome` `^2.4.16`.
- **`i18next` pinned to `26.3.0`** (exact). `26.3.1` was published <24h ago and trips the `minimumReleaseAge` policy above; since i18next is third-party (not covered by the `@alienfast/*` allowlist) it's pinned to the prior, functionally-equivalent release and can be bumped once 26.3.1 ages out.

## Testing

- ✅ `pnpm install --frozen-lockfile` — passes pnpm 11's supply-chain policy check (the exact CI command), token-free (public npm), esbuild/biome build scripts approved via `allowBuilds`
- ✅ `pnpm build` — ESM + DTS (4 files)
- ✅ `pnpm check-types`
- ✅ `pnpm test` — 18 passed
- ✅ `pnpm check-biome` — no findings
- ✅ no `npm.pkg.github.com` references remain (config or lockfile)

## Note
The `v4.0.0` GitHub Release is still missing (the failed run). Once this merges, future releases will create it correctly; the existing `v4.0.0` can be backfilled separately from the existing tag if desired.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)